### PR TITLE
[AIRFLOW-2310]: Added AWS Glue Job Compatibility to Airflow

### DIFF
--- a/airflow/contrib/aws_glue_job_hook.py
+++ b/airflow/contrib/aws_glue_job_hook.py
@@ -1,0 +1,212 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+
+from airflow.exceptions import AirflowException
+from airflow.contrib.hooks.aws_hook import AwsHook
+import os.path
+import time
+
+
+class AwsGlueJobHook(AwsHook):
+    """
+    Interact with AWS Glue - create job, trigger, crawler
+
+    :param job_name: unique job name per AWS account
+    :type str
+    :param desc: job description
+    :type str
+    :param concurrent_run_limit: The maximum number of concurrent runs allowed for a job
+    :type int
+    :param script_location: path to etl script either on s3 or local
+    :type str
+    :param conns: A list of connections used by the job
+    :type list
+    :param retry_limit: Maximum number of times to retry this job if it fails
+    :type int
+    :param num_of_dpus: Number of AWS Glue DPUs to allocate to this Job
+    :type int
+    :param region_name: aws region name (example: us-east-1)
+    :type region_name: str
+    :param s3_bucket: S3 bucket where logs and local etl script will be uploaded
+    :type str
+    :param iam_role_name: AWS IAM Role for Glue Job
+    :type str
+    """
+
+    def __init__(self,
+                 job_name=None,
+                 desc=None,
+                 concurrent_run_limit=None,
+                 script_location=None,
+                 conns=None,
+                 retry_limit=None,
+                 num_of_dpus=None,
+                 aws_conn_id='aws_default',
+                 region_name=None,
+                 iam_role_name=None,
+                 s3_bucket=None, *args, **kwargs):
+        self.job_name = job_name
+        self.desc = desc
+        self.concurrent_run_limit = concurrent_run_limit or 1
+        self.script_location = script_location
+        self.conns = conns or ["s3"]
+        self.retry_limit = retry_limit or 0
+        self.num_of_dpus = num_of_dpus or 10
+        self.aws_conn_id = aws_conn_id
+        self.region_name = region_name
+        self.s3_bucket = s3_bucket
+        self.role_name = iam_role_name
+        self.S3_PROTOCOL = "s3://"
+        self.S3_ARTIFACTS_PREFIX = 'artifacts/glue-scripts/'
+        self.S3_GLUE_LOGS = 'logs/glue-logs/'
+        super(AwsGlueJobHook, self).__init__(*args, **kwargs)
+
+    def get_conn(self):
+        conn = self.get_client_type('glue', self.region_name)
+        return conn
+
+    def list_jobs(self):
+        conn = self.get_conn()
+        return conn.get_jobs()
+
+    def get_iam_execution_role(self):
+        """
+        :return: iam role for job execution
+        """
+        iam_client = self.get_client_type('iam', self.region_name)
+
+        try:
+            glue_execution_role = iam_client.get_role(RoleName=self.role_name)
+            self.log.info("Iam Role Name: {}".format(self.role_name))
+            return glue_execution_role
+        except Exception as general_error:
+            raise AirflowException(
+                'Failed to create aws glue job, error: {error}'.format(
+                    error=str(general_error)
+                )
+            )
+
+    def initialize_job(self, script_arguments=None):
+        """
+        Initializes connection with AWS Glue
+        to run job
+        :return:
+        """
+        if self.s3_bucket is None:
+            raise AirflowException(
+                'Could not initialize glue job, '
+                'error: Specify Parameter `s3_bucket`'
+            )
+
+        glue_client = self.get_conn()
+
+        try:
+            job_response = self.get_or_create_glue_job()
+            job_name = job_response['Name']
+            job_run = glue_client.start_job_run(
+                JobName=job_name,
+                Arguments=script_arguments
+            )
+            return self.job_completion(job_name, job_run['JobRunId'])
+        except Exception as general_error:
+            raise AirflowException(
+                'Failed to run aws glue job, error: {error}'.format(
+                    error=str(general_error)
+                )
+            )
+
+    def job_completion(self, job_name=None, run_id=None):
+        """
+        :param job_name:
+        :param run_id:
+        :return:
+        """
+        glue_client = self.get_conn()
+        job_status = glue_client.get_job_run(
+            JobName=job_name,
+            RunId=run_id,
+            PredecessorsIncluded=True
+        )
+        job_run_state = job_status['JobRun']['JobRunState']
+        failed = job_run_state == 'FAILED'
+        stopped = job_run_state == 'STOPPED'
+        completed = job_run_state == 'SUCCEEDED'
+
+        while True:
+            if failed or stopped or completed:
+                self.log.info("Exiting Job {} Run State: {}"
+                              .format(run_id, job_run_state))
+                return {'JobRunState': job_run_state, 'JobRunId': run_id}
+            else:
+                self.log.info("Polling for AWS Glue Job {} current run state"
+                              .format(job_name))
+                time.sleep(6)
+
+    def get_or_create_glue_job(self):
+        glue_client = self.get_conn()
+        try:
+            self.log.info("Now creating and running AWS Glue Job")
+            s3_log_path = "s3://{bucket_name}/{logs_path}{job_name}"\
+                .format(bucket_name=self.s3_bucket,
+                        logs_path=self.S3_GLUE_LOGS,
+                        job_name=self.job_name)
+
+            execution_role = self.get_iam_execution_role()
+            script_location = self._check_script_location()
+            create_job_response = glue_client.create_job(
+                Name=self.job_name,
+                Description=self.desc,
+                LogUri=s3_log_path,
+                Role=execution_role['Role']['RoleName'],
+                ExecutionProperty={"MaxConcurrentRuns": self.concurrent_run_limit},
+                Command={"Name": "glueetl", "ScriptLocation": script_location},
+                MaxRetries=self.retry_limit,
+                AllocatedCapacity=self.num_of_dpus
+            )
+            # print(create_job_response)
+            return create_job_response
+        except Exception as general_error:
+            raise AirflowException(
+                'Failed to create aws glue job, error: {error}'.format(
+                    error=str(general_error)
+                )
+            )
+
+    def _check_script_location(self):
+        """
+        :return: S3 Script location path
+        """
+        if self.script_location[:5] == self.S3_PROTOCOL:
+            return self.script_location
+        elif os.path.isfile(self.script_location):
+            s3 = self.get_resource_type('s3', self.region_name)
+            script_name = os.path.basename(self.script_location)
+            s3.meta.client.upload_file(self.script_location,
+                                       self.s3_bucket,
+                                       self.S3_ARTIFACTS_PREFIX + script_name)
+
+            s3_script_path = "s3://{s3_bucket}/{prefix}{job_name}/{script_name}" \
+                .format(s3_bucket=self.s3_bucket,
+                        prefix=self.S3_ARTIFACTS_PREFIX,
+                        job_name=self.job_name,
+                        script_name=script_name)
+            return s3_script_path
+        else:
+            return None

--- a/airflow/contrib/hooks/aws_glue_job_hook.py
+++ b/airflow/contrib/hooks/aws_glue_job_hook.py
@@ -1,0 +1,210 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from airflow.exceptions import AirflowException
+from airflow.contrib.hooks.aws_hook import AwsHook
+import os.path
+import time
+
+
+class AwsGlueJobHook(AwsHook):
+    """
+    Interact with AWS Glue - create job, trigger, crawler
+
+    :param job_name: unique job name per AWS account
+    :type str
+    :param desc: job description
+    :type str
+    :param concurrent_run_limit: The maximum number of concurrent runs allowed for a job
+    :type int
+    :param script_location: path to etl script either on s3 or local
+    :type str
+    :param conns: A list of connections used by the job
+    :type list
+    :param retry_limit: Maximum number of times to retry this job if it fails
+    :type int
+    :param num_of_dpus: Number of AWS Glue DPUs to allocate to this Job
+    :type int
+    :param region_name: aws region name (example: us-east-1)
+    :type region_name: str
+    :param s3_bucket: S3 bucket where logs and local etl script will be uploaded
+    :type str
+    :param iam_role_name: AWS IAM Role for Glue Job
+    :type str
+    """
+
+    def __init__(self,
+                 job_name=None,
+                 desc=None,
+                 concurrent_run_limit=None,
+                 script_location=None,
+                 conns=None,
+                 retry_limit=None,
+                 num_of_dpus=None,
+                 aws_conn_id='aws_default',
+                 region_name=None,
+                 iam_role_name=None,
+                 s3_bucket=None, *args, **kwargs):
+        self.job_name = job_name
+        self.desc = desc
+        self.concurrent_run_limit = concurrent_run_limit or 1
+        self.script_location = script_location
+        self.conns = conns or ["s3"]
+        self.retry_limit = retry_limit or 0
+        self.num_of_dpus = num_of_dpus or 10
+        self.aws_conn_id = aws_conn_id
+        self.region_name = region_name
+        self.s3_bucket = s3_bucket
+        self.role_name = iam_role_name
+        self.S3_PROTOCOL = "s3://"
+        self.S3_ARTIFACTS_PREFIX = 'artifacts/glue-scripts/'
+        self.S3_GLUE_LOGS = 'logs/glue-logs/'
+        super(AwsGlueJobHook, self).__init__(*args, **kwargs)
+
+    def get_conn(self):
+        conn = self.get_client_type('glue', self.region_name)
+        return conn
+
+    def list_jobs(self):
+        conn = self.get_conn()
+        return conn.get_jobs()
+
+    def get_iam_execution_role(self):
+        """
+        :return: iam role for job execution
+        """
+        iam_client = self.get_client_type('iam', self.region_name)
+
+        try:
+            glue_execution_role = iam_client.get_role(RoleName=self.role_name)
+            self.log.info("Iam Role Name: {}".format(self.role_name))
+            return glue_execution_role
+        except Exception as general_error:
+            raise AirflowException(
+                'Failed to create aws glue job, error: {error}'.format(
+                    error=str(general_error)
+                )
+            )
+
+    def initialize_job(self, script_arguments=None):
+        """
+        Initializes connection with AWS Glue
+        to run job
+        :return:
+        """
+        if self.s3_bucket is None:
+            raise AirflowException(
+                'Could not initialize glue job, '
+                'error: Specify Parameter `s3_bucket`'
+            )
+
+        glue_client = self.get_conn()
+
+        try:
+            job_response = self.get_or_create_glue_job()
+            job_name = job_response['Name']
+            job_run = glue_client.start_job_run(
+                JobName=job_name,
+                Arguments=script_arguments
+            )
+            return self.job_completion(job_name, job_run['JobRunId'])
+        except Exception as general_error:
+            raise AirflowException(
+                'Failed to run aws glue job, error: {error}'.format(
+                    error=str(general_error)
+                )
+            )
+
+    def job_completion(self, job_name=None, run_id=None):
+        """
+        :param job_name:
+        :param run_id:
+        :return:
+        """
+        glue_client = self.get_conn()
+        job_status = glue_client.get_job_run(
+            JobName=job_name,
+            RunId=run_id,
+            PredecessorsIncluded=True
+        )
+        job_run_state = job_status['JobRun']['JobRunState']
+        failed = job_run_state == 'FAILED'
+        stopped = job_run_state == 'STOPPED'
+        completed = job_run_state == 'SUCCEEDED'
+
+        while True:
+            if failed or stopped or completed:
+                self.log.info("Exiting Job {} Run State: {}"
+                              .format(run_id, job_run_state))
+                return {'JobRunState': job_run_state, 'JobRunId': run_id}
+            else:
+                self.log.info("Polling for AWS Glue Job {} current run state"
+                              .format(job_name))
+                time.sleep(6)
+
+    def get_or_create_glue_job(self):
+        glue_client = self.get_conn()
+        try:
+            self.log.info("Now creating and running AWS Glue Job")
+            s3_log_path = "s3://{bucket_name}/{logs_path}{job_name}"\
+                .format(bucket_name=self.s3_bucket,
+                        logs_path=self.S3_GLUE_LOGS,
+                        job_name=self.job_name)
+
+            execution_role = self.get_iam_execution_role()
+            script_location = self._check_script_location()
+            create_job_response = glue_client.create_job(
+                Name=self.job_name,
+                Description=self.desc,
+                LogUri=s3_log_path,
+                Role=execution_role['Role']['RoleName'],
+                ExecutionProperty={"MaxConcurrentRuns": self.concurrent_run_limit},
+                Command={"Name": "glueetl", "ScriptLocation": script_location},
+                MaxRetries=self.retry_limit,
+                AllocatedCapacity=self.num_of_dpus
+            )
+            # print(create_job_response)
+            return create_job_response
+        except Exception as general_error:
+            raise AirflowException(
+                'Failed to create aws glue job, error: {error}'.format(
+                    error=str(general_error)
+                )
+            )
+
+    def _check_script_location(self):
+        """
+        :return: S3 Script location path
+        """
+        if self.script_location[:5] == self.S3_PROTOCOL:
+            return self.script_location
+        elif os.path.isfile(self.script_location):
+            s3 = self.get_resource_type('s3', self.region_name)
+            script_name = os.path.basename(self.script_location)
+            s3.meta.client.upload_file(self.script_location,
+                                       self.s3_bucket,
+                                       self.S3_ARTIFACTS_PREFIX + script_name)
+
+            s3_script_path = "s3://{s3_bucket}/{prefix}{job_name}/{script_name}" \
+                .format(s3_bucket=self.s3_bucket,
+                        prefix=self.S3_ARTIFACTS_PREFIX,
+                        job_name=self.job_name,
+                        script_name=script_name)
+            return s3_script_path
+        else:
+            return None

--- a/airflow/contrib/operators/aws_glue_job_operator.py
+++ b/airflow/contrib/operators/aws_glue_job_operator.py
@@ -1,0 +1,113 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+from __future__ import unicode_literals
+
+from airflow.contrib.hooks.aws_glue_job_hook import AwsGlueJobHook
+from airflow.models import BaseOperator
+from airflow.utils.decorators import apply_defaults
+
+
+class AWSGlueJobOperator(BaseOperator):
+    """
+    Creates an AWS Glue Job. AWS Glue is a serverless Spark
+    ETL service for running Spark Jobs on the AWS cloud.
+    Language support: Python and Scala
+    :param job_name: unique job name per AWS Account
+    :type str
+    :param script_location: location of ETL script. Must be a local or S3 path
+    :type str
+    :param job_desc: job description details
+    :type str
+    :param concurrent_run_limit: The maximum number of concurrent runs allowed for a job
+    :type int
+    :param script_args: etl script arguments and AWS Glue arguments
+    :type dict
+    :param connections: AWS Glue connections to be used by the job.
+    :type list
+    :param retry_limit: The maximum number of times to retry this job if it fails
+    :type int
+    :param num_of_dpus: Number of AWS Glue DPUs to allocate to this Job.
+    :type int
+    :param region_name: aws region name (example: us-east-1)
+    :type region_name: str
+    :param s3_bucket: S3 bucket where logs and local etl script will be uploaded
+    :type str
+    :param iam_role_name: AWS IAM Role for Glue Job Execution
+    :type str
+    """
+    template_fields = ()
+    template_ext = ()
+    ui_color = '#ededed'
+
+    @apply_defaults
+    def __init__(self,
+                 job_name='aws_glue_default_job',
+                 job_desc='AWS Glue Job with Airflow',
+                 script_location=None,
+                 concurrent_run_limit=None,
+                 script_args={},
+                 connections=[],
+                 retry_limit=None,
+                 num_of_dpus=6,
+                 aws_conn_id='aws_default',
+                 region_name=None,
+                 s3_bucket=None,
+                 iam_role_name=None,
+                 *args, **kwargs
+                 ):
+        super(AWSGlueJobOperator, self).__init__(*args, **kwargs)
+        self.job_name = job_name
+        self.job_desc = job_desc
+        self.script_location = script_location
+        self.concurrent_run_limit = concurrent_run_limit
+        self.script_args = script_args
+        self.connections = connections
+        self.retry_limit = retry_limit
+        self.num_of_dpus = num_of_dpus
+        self.aws_conn_id = aws_conn_id,
+        self.region_name = region_name
+        self.s3_bucket = s3_bucket
+        self.iam_role_name = iam_role_name
+
+    def execute(self, context):
+        """
+        Executes AWS Glue Job from Airflow
+        :return:
+        """
+        glue_job = AwsGlueJobHook(job_name=self.job_name,
+                                  desc=self.job_desc,
+                                  concurrent_run_limit=self.concurrent_run_limit,
+                                  script_location=self.script_location,
+                                  conns=self.connections,
+                                  retry_limit=self.retry_limit,
+                                  num_of_dpus=self.num_of_dpus,
+                                  aws_conn_id=self.aws_conn_id,
+                                  region_name=self.region_name,
+                                  s3_bucket=self.s3_bucket,
+                                  iam_role_name=self.iam_role_name)
+
+        self.log.info("Initializing AWS Glue Job: {}".format(self.job_name))
+        glue_job_run = glue_job.initialize_job(self.script_args)
+        self.log.info('AWS Glue Job: {job_name} status: {job_status}. Run Id: {run_id}'
+                      .format(run_id=glue_job_run['JobRunId'],
+                              job_name=self.job_name,
+                              job_status=glue_job_run['JobRunState'])
+                      )
+
+        self.log.info('Done.')

--- a/airflow/contrib/sensors/aws_glue_job_sensor.py
+++ b/airflow/contrib/sensors/aws_glue_job_sensor.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+from airflow.sensors.base_sensor_operator import BaseSensorOperator
+from airflow.utils.decorators import apply_defaults
+from airflow.contrib.hooks.aws_glue_job_hook import AwsGlueJobHook
+
+
+class AwsGlueJobSensor(BaseSensorOperator):
+    """
+    Waits for an AWS Glue Job to reach any of the status below
+    'FAILED', 'STOPPED', 'SUCCEEDED'
+
+    :param job_name: The AWS Glue Job unique name
+    :type str
+    :param run_id: The AWS Glue current running job identifier
+    :type str
+    """
+    template_fields = ('job_name', 'run_id')
+
+    @apply_defaults
+    def __init__(self,
+                 job_name,
+                 run_id,
+                 aws_conn_id='aws_default',
+                 *args,
+                 **kwargs):
+        super(AwsGlueJobSensor, self).__init__(*args, **kwargs)
+        self.job_name = job_name
+        self.run_id = run_id
+        self.aws_conn_id = aws_conn_id
+        self.targeted_status = ['FAILED', 'STOPPED', 'SUCCEEDED']
+
+    def poke(self, context):
+        self.log.info("Poking for job run status : {self.targeted_status}\n"
+                      "for Glue Job {self.job_name} and ID {self.run_id}"
+                      .format(**locals()))
+        hook = AwsGlueJobHook(aws_conn_id=self.aws_conn_id)
+        job_state = hook.job_completion(job_name=self.job_name,
+                                        run_id=self.run_id)
+        return job_state.upper() in self.targeted_status

--- a/docs/code.rst
+++ b/docs/code.rst
@@ -111,6 +111,7 @@ Operators
 .. Alphabetize this list
 
 .. autoclass:: airflow.contrib.operators.awsbatch_operator.AWSBatchOperator
+.. autoclass:: airflow.contrib.operators.aws_glue_job_operator.AWSGlueJobOperator
 .. autoclass:: airflow.contrib.operators.bigquery_check_operator.BigQueryCheckOperator
 .. autoclass:: airflow.contrib.operators.bigquery_check_operator.BigQueryValueCheckOperator
 .. autoclass:: airflow.contrib.operators.bigquery_check_operator.BigQueryIntervalCheckOperator
@@ -193,6 +194,7 @@ Sensors
 ^^^^^^^
 
 .. autoclass:: airflow.contrib.sensors.aws_redshift_cluster_sensor.AwsRedshiftClusterSensor
+.. autoclass:: airflow.contrib.sensors.aws_glue_job_sensor.AwsGlueJobSensor
 .. autoclass:: airflow.contrib.sensors.bash_sensor.BashSensor
 .. autoclass:: airflow.contrib.sensors.bigquery_sensor.BigQueryTableSensor
 .. autoclass:: airflow.contrib.sensors.datadog_sensor.DatadogSensor
@@ -358,6 +360,7 @@ Community contributed hooks
 '''''''''''''''''''''''''''
 .. Alphabetize this list
 .. autoclass:: airflow.contrib.hooks.aws_dynamodb_hook.AwsDynamoDBHook
+.. autoclass:: airflow.contrib.hooks.aws_glue_job_hook.AwsGlueJobHook
 .. autoclass:: airflow.contrib.hooks.aws_hook.AwsHook
 .. autoclass:: airflow.contrib.hooks.aws_lambda_hook.AwsLambdaHook
 .. autoclass:: airflow.contrib.hooks.bigquery_hook.BigQueryHook

--- a/tests/contrib/hooks/test_aws_glue_job_hook.py
+++ b/tests/contrib/hooks/test_aws_glue_job_hook.py
@@ -7,17 +7,15 @@
 # to you under the Apache License, Version 2.0 (the
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
-# 
+#
 #   http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an
 # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 # KIND, either express or implied.  See the License for the
 # specific language governing permissions and limitations
 # under the License.
-#
-
 import unittest
 import json
 

--- a/tests/contrib/hooks/test_aws_glue_job_hook.py
+++ b/tests/contrib/hooks/test_aws_glue_job_hook.py
@@ -1,0 +1,121 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+# 
+#   http://www.apache.org/licenses/LICENSE-2.0
+# 
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+import unittest
+import json
+
+
+try:
+    from unittest import mock
+except ImportError:
+    try:
+        import mock
+    except ImportError:
+        mock = None
+
+try:
+    from moto import mock_iam
+except ImportError:
+    mock_iam = None
+
+
+from airflow.contrib.hooks.aws_glue_job_hook import AwsGlueJobHook
+
+
+class TestGlueJobHook(unittest.TestCase):
+
+    def setUp(self):
+        self.some_aws_region = "us-west-2"
+
+    @mock.patch.object(AwsGlueJobHook, 'get_conn')
+    def test_get_conn_returns_a_boto3_connection(self, mock_get_conn):
+        hook = AwsGlueJobHook(job_name='aws_test_glue_job', s3_bucket='some_bucket')
+        self.assertIsNotNone(hook.get_conn())
+
+    @unittest.skipIf(mock_iam is None, 'mock_iam package not present')
+    @mock_iam
+    def test_get_iam_execution_role(self):
+        hook = AwsGlueJobHook(job_name='aws_test_glue_job',
+                              s3_bucket='some_bucket',
+                              iam_role_name='my_test_role')
+        iam_role = hook.get_client_type('iam').create_role(
+            Path="/",
+            RoleName='my_test_role',
+            AssumeRolePolicyDocument=json.dumps({
+                "Version": "2012-10-17",
+                "Statement": {
+                    "Effect": "Allow",
+                    "Principal": {"Service": "glue.amazonaws.com"},
+                    "Action": "sts:AssumeRole"
+                }
+            })
+        )
+        iam_role = hook.get_iam_execution_role()
+        self.assertIsNotNone(iam_role)
+
+    @mock.patch.object(AwsGlueJobHook, "_check_script_location")
+    @mock.patch.object(AwsGlueJobHook, "get_iam_execution_role")
+    @mock.patch.object(AwsGlueJobHook, "get_conn")
+    def test_get_or_create_glue_job(self, mock_get_conn,
+                                    mock_get_iam_execution_role,
+                                    mock_script):
+        mock_get_iam_execution_role.return_value = \
+            mock.MagicMock(Role={'RoleName': 'my_test_role'})
+        some_script = "s3:/glue-examples/glue-scripts/sample_aws_glue_job.py"
+        some_s3_bucket = "my-includes"
+        mock_script.return_value = mock.Mock(return_value=some_script)
+
+        mock_glue_job = mock_get_conn.return_value.create_job()
+        glue_job = AwsGlueJobHook(job_name='aws_test_glue_job',
+                                  desc='This is test case job from Airflow',
+                                  script_location=some_script,
+                                  iam_role_name='my_test_role',
+                                  s3_bucket=some_s3_bucket,
+                                  region_name=self.some_aws_region)\
+            .get_or_create_glue_job()
+        self.assertEqual(glue_job, mock_glue_job)
+
+    @mock.patch.object(AwsGlueJobHook, "job_completion")
+    @mock.patch.object(AwsGlueJobHook, "get_or_create_glue_job")
+    @mock.patch.object(AwsGlueJobHook, "get_conn")
+    def test_initialize_job(self, mock_get_conn,
+                            mock_get_or_create_glue_job,
+                            mock_completion):
+        some_data_path = "s3://glue-datasets/examples/medicare/SampleData.csv"
+        some_script_arguments = {"--s3_input_data_path": some_data_path}
+        some_script = "s3:/glue-examples/glue-scripts/sample_aws_glue_job.py"
+        some_s3_bucket = "my-includes"
+
+        mock_get_or_create_glue_job.Name = mock.Mock(Name='aws_test_glue_job')
+        mock_get_conn.return_value.start_job_run()
+
+        mock_job_run_state = mock_completion.return_value
+        glue_job_run_state = AwsGlueJobHook(job_name='aws_test_glue_job',
+                                            desc='This is test case job from Airflow',
+                                            iam_role_name='my_test_role',
+                                            script_location=some_script,
+                                            s3_bucket=some_s3_bucket,
+                                            region_name=self.some_aws_region)\
+            .initialize_job(some_script_arguments)
+        self.assertEqual(glue_job_run_state, mock_job_run_state, msg='Mocks but be equal')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/contrib/operators/test_aws_glue_job_operator.py
+++ b/tests/contrib/operators/test_aws_glue_job_operator.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import unittest
+
+from airflow import configuration
+from airflow.contrib.hooks.aws_glue_job_hook import AwsGlueJobHook
+from airflow.contrib.operators.aws_glue_job_operator import AWSGlueJobOperator
+
+try:
+    from unittest import mock
+except ImportError:
+    try:
+        import mock
+    except ImportError:
+        mock = None
+
+
+class TestAwsGlueJobOperator(unittest.TestCase):
+
+    @mock.patch('airflow.contrib.operators.aws_glue_job_operator.AwsGlueJobHook')
+    def setUp(self, glue_hook_mock):
+        configuration.load_test_config()
+
+        self.glue_hook_mock = glue_hook_mock
+        some_script = "s3:/glue-examples/glue-scripts/sample_aws_glue_job.py"
+        self.glue = AWSGlueJobOperator(task_id='test_glue_operator',
+                                       job_name='my_test_job',
+                                       script_location=some_script,
+                                       aws_conn_id='aws_default',
+                                       region_name='us-west-2',
+                                       s3_bucket='some_bucket',
+                                       iam_role_name='my_test_role')
+
+    @mock.patch.object(AwsGlueJobHook, 'initialize_job')
+    def test_execute_without_failure(self, mock_initialize_job):
+        mock_initialize_job.return_value = {'JobRunState': 'RUNNING', 'JobRunId': '11111'}
+        self.glue.execute(None)
+
+        mock_initialize_job.assert_called_once_with({})
+        self.assertEqual(self.glue.job_name, 'my_test_job')

--- a/tests/sensors/test_aws_glue_job_sensor.py
+++ b/tests/sensors/test_aws_glue_job_sensor.py
@@ -1,0 +1,69 @@
+# -*- coding: utf-8 -*-
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+import unittest
+
+from airflow import configuration
+from airflow.contrib.hooks.aws_glue_job_hook import AwsGlueJobHook
+from airflow.contrib.sensors.aws_glue_job_sensor import AwsGlueJobSensor
+
+
+try:
+    from unittest import mock
+except ImportError:
+    try:
+        import mock
+    except ImportError:
+        mock = None
+
+
+class TestAwsGlueJobSensor(unittest.TestCase):
+
+    def setUp(self):
+        configuration.load_test_config()
+
+    @mock.patch.object(AwsGlueJobHook, 'get_conn')
+    @mock.patch.object(AwsGlueJobHook, 'job_completion')
+    def test_poke(self, mock_job_completion, mock_conn):
+        mock_conn.return_value.get_job_run()
+        mock_job_completion.return_value = 'SUCCEEDED'
+        op = AwsGlueJobSensor(task_id='test_glue_job_sensor',
+                              job_name='aws_test_glue_job',
+                              run_id='5152fgsfsjhsh61661',
+                              poke_interval=1,
+                              timeout=5,
+                              aws_conn_id='aws_default')
+        self.assertTrue(op.poke(None))
+
+    @mock.patch.object(AwsGlueJobHook, 'get_conn')
+    @mock.patch.object(AwsGlueJobHook, 'job_completion')
+    def test_poke_false(self, mock_job_completion, mock_conn):
+        mock_conn.return_value.get_job_run()
+        mock_job_completion.return_value = 'RUNNING'
+        op = AwsGlueJobSensor(task_id='test_glue_job_sensor',
+                              job_name='aws_test_glue_job',
+                              run_id='5152fgsfsjhsh61661',
+                              poke_interval=1,
+                              timeout=5,
+                              aws_conn_id='aws_default')
+        self.assertFalse(op.poke(None))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Make sure you have checked _all_ steps below.

### JIRA
- [x] My PR addresses the following [Airflow JIRA](https://issues.apache.org/jira/browse/AIRFLOW/) issues and references them in the PR title. For example, "\[AIRFLOW-XXX\] My Airflow PR"
    - https://issues.apache.org/jira/projects/AIRFLOW/issues/AIRFLOW-2310
    - In case you are fixing a typo in the documentation you can prepend your commit with \[AIRFLOW-XXX\], code changes always need a JIRA issue.


### Description
- [x] Here are some details about my PR, including screenshots of any UI changes:
Currently, there is no integration with AWS Glue Jobs. My pull request is basically an improvement to integrate running AWS Glue jobs with Airflow.


### Tests
- [x] My PR adds the following unit tests __OR__ does not need testing for this extremely good reason:
Added tests.contrib.test_aws_glue_job_hook.py.
However, moto the test class for boto3 does not support AWS Glue mock currently

### Commits
- [x] My commits all reference JIRA issues in their subject lines, and I have squashed multiple commits if they address the same issue. In addition, my commits follow the guidelines from "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)":
    1. Subject is separated from body by a blank line
    2. Subject is limited to 50 characters
    3. Subject does not end with a period
    4. Subject uses the imperative mood ("add", not "adding")
    5. Body wraps at 72 characters
    6. Body explains "what" and "why", not "how"

- [x] Passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
